### PR TITLE
Theorem 1 (part 1)

### DIFF
--- a/FormalBook/Chapter_45.lean
+++ b/FormalBook/Chapter_45.lean
@@ -63,6 +63,21 @@ theorem remark_1 {d : ℕ} : ∃ α : Type, ∃ X : Finset α, ∃ 𝓕 : Finset
     simp +contextual [Finset.subset_iff]
 
 
+/--
+In Book:
+"On the other hand, it is equally clear that every subfamily of a 2-colorable family of
+d-sets is itself 2-colorable."
+-/
+theorem remark_2 {𝓕 𝓢 : Finset (Finset X)}
+  (h₁ : two_colorable 𝓕)  (h₂ : 𝓢 ⊆ 𝓕) : two_colorable 𝓢 := by
+  refine h₁.imp ?_
+  intro coloring h₃ A Amem
+  exact h₃ A (h₂ Amem)
+
+
+
+
+#exit
 
 --include H_𝓕 (H_𝓕 : ∀ (A : Finset X), A ∈ 𝓕 → A.card = d)
 theorem theorem_1 (𝓕 : Finset (Finset X)) : 𝓕.card ≤ 2 ^ (d-1) → two_colorable 𝓕 :=

--- a/FormalBook/Chapter_45.lean
+++ b/FormalBook/Chapter_45.lean
@@ -79,6 +79,17 @@ theorem remark_2 {𝓕 𝓢 : Finset (Finset X)}
   exact h₃ A (h₂ Amem)
 
 
+open ENNReal NNReal
+
+-- based on ENNReal.mul_inv_cancel
+protected lemma ENNReal.mul_inv_eq_iff_eq_mul {a b c: ENNReal}
+  (h0 : b ≠ 0) (ha : a ≠ ∞) (hb : b ≠ ∞) (hc : c ≠ ∞) :
+  a * b⁻¹ = c ↔ a = c * b := by
+    lift a to ℝ≥0 using ha
+    lift b to ℝ≥0 using hb
+    lift c to ℝ≥0 using hc
+    norm_cast at h0; norm_cast
+    apply mul_inv_eq_iff_eq_mul₀ h0
 
 #check PMF.uniformOfFinset
 #check PMF.uniformOfFintype
@@ -89,10 +100,11 @@ open MeasureTheory
 
 theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈ 𝓕 → A.card = d)
   : 𝓕.card ≤ 2 ^ (d-1) → two_colorable 𝓕 := by
+  intro bnd
   have I : Fintype ({ x // x ∈ X } → Fin 2) := (by apply Fintype.ofFinite)
   set P : Measure (X → Fin 2) := (PMF.uniformOfFintype (X → Fin 2)).toMeasure with Pdef
   set E : (Finset X) → Finset (X → Fin 2) := (fun A => {c | ∀ x ∈ A, ∀ y ∈ A, c x = c y}) with Edef
-  have probaEA (A : Finset X) (hA : A ∈ 𝓕) : P (E A) = (1 / 2)^(d-1) := by
+  have probaEA (A : Finset X) (hA : A ∈ 𝓕) : P (E A) = (1 / 2)^(d-1 : ℤ) := by
     rw [Pdef, PMF.toMeasure_uniformOfFintype_apply]
     · nth_rw 2 [← Nat.card_eq_fintype_card]
       rw [Nat.card_fun]
@@ -102,9 +114,21 @@ theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈
         Nat.cast_pow, Nat.cast_ofNat, one_div]
       rw [sizeEA]
       simp only [Nat.cast_pow, Nat.cast_ofNat]
-      sorry
-    · sorry
+      rw [div_eq_mul_inv, ENNReal.mul_inv_eq_iff_eq_mul (by simp) (by simp) (by simp) (by sorry)]
+      rw [ENNReal.inv_zpow' 2 (d-1), ]
+      rw [show (2 : ENNReal) ^ #X = 2 ^ (#X : ℤ) from by rw [zpow_natCast]]
+      rw [show (2 : ENNReal) ^ (#X - #A + 1) = 2 ^ ((#X - #A + 1) : ℤ) from by sorry ]
+      rw [← ENNReal.zpow_add (by simp) (by simp)]
+      rw [neg_sub, H_𝓕 A hA]
+      congr 1
+      ring
+    · --measurability -- @Moritz ; solves it, but is slow
+      exact Set.Finite.measurableSet <| finite_toSet (E A)
   sorry
+
+
+#check pow_eq_top_iff
+#check WithTop.pow_eq_top_iff
 
 #check card_pos
 
@@ -122,6 +146,22 @@ theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈
 #check DiscreteMeasurableSpace
 
 #check MeasurableSet.singleton
+
+#check div_pow
+#check div_eq_mul_inv
+#check mul_inv_eq_iff_eq_mul₀
+#check ENNReal.zpow_add
+
+#check measure_ne_top
+#check measure_lt_top
+
+#check zpow_eq_neg_zpow_iff₀
+
+#check zpow_add₀
+
+
+
+#check
 
 
 #exit

--- a/FormalBook/Chapter_45.lean
+++ b/FormalBook/Chapter_45.lean
@@ -159,7 +159,7 @@ theorem theorem_1 {h_d : d ≥ 2} (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : 
 
 
 
-#exit
+
 
 /-! Ramsey Numbers and Theorem 2-/
 

--- a/FormalBook/Chapter_45.lean
+++ b/FormalBook/Chapter_45.lean
@@ -67,11 +67,6 @@ theorem remark_1 {d : ℕ} : ∃ α : Type, ∃ X : Finset α, ∃ 𝓕 : Finset
     simp +contextual [Finset.subset_iff]
 
 
-/--
-In Book:
-"On the other hand, it is equally clear that every subfamily of a 2-colorable family of
-d-sets is itself 2-colorable."
--/
 theorem remark_2 {𝓕 𝓢 : Finset (Finset X)}
   (h₁ : two_colorable 𝓕)  (h₂ : 𝓢 ⊆ 𝓕) : two_colorable 𝓢 := by
   apply h₁.imp ?_
@@ -81,7 +76,6 @@ theorem remark_2 {𝓕 𝓢 : Finset (Finset X)}
 
 open ENNReal NNReal
 
--- based on ENNReal.mul_inv_cancel
 protected lemma ENNReal.mul_inv_eq_iff_eq_mul {a b c: ENNReal}
   (h0 : b ≠ 0) (ha : a ≠ ∞) (hb : b ≠ ∞) (hc : c ≠ ∞) :
   a * b⁻¹ = c ↔ a = c * b := by
@@ -121,42 +115,8 @@ theorem theorem_1 {h_d : d ≥ 2} (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : 
       congr 1
       simp only [Nat.cast_add, Nat.cast_one, @Nat.cast_sub _ _ d #X forComp]
       ring
-    · --measurability -- @Moritz ; solves it, but is slow
-      exact Set.Finite.measurableSet <| finite_toSet (E A)
+    · exact Set.Finite.measurableSet <| finite_toSet (E A)
   sorry
-
-
-#check pow_eq_top_iff
-#check WithTop.pow_eq_top_iff
-#check card_pos
-#check card_pi
-#check Nat.card_fun
-#check Nat.card
-#check card
-#check Nat.card_eq_fintype_card
-#check Nat.card_eq_finsetCard
-#check Fintype.ofFinite
-#check PMF.uniformOfFintype_apply
-#check PMF.toMeasure_apply_fintype
-#check PMF.toMeasure
-#check MeasurableSet.of_discrete
-#check DiscreteMeasurableSpace
-#check MeasurableSet.singleton
-#check div_pow
-#check div_eq_mul_inv
-#check mul_inv_eq_iff_eq_mul₀
-#check ENNReal.zpow_add
-#check ENNReal.inv_pow
-#check measure_ne_top
-#check measure_lt_top
-#check zpow_eq_neg_zpow_iff₀
-#check zpow_add₀
-#check card_le_univ
-#check PMF.uniformOfFinset
-#check PMF.uniformOfFintype
-#check PMF.toMeasure_apply
-#check MeasureTheory.measure_biUnion_le
-
 
 
 

--- a/FormalBook/Chapter_45.lean
+++ b/FormalBook/Chapter_45.lean
@@ -91,20 +91,17 @@ protected lemma ENNReal.mul_inv_eq_iff_eq_mul {a b c: ENNReal}
     norm_cast at h0; norm_cast
     apply mul_inv_eq_iff_eq_mul₀ h0
 
-#check PMF.uniformOfFinset
-#check PMF.uniformOfFintype
-#check PMF.toMeasure_apply
-#check MeasureTheory.measure_biUnion_le
-
 open MeasureTheory
 
-theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈ 𝓕 → A.card = d)
+theorem theorem_1 {h_d : d ≥ 2} (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈ 𝓕 → A.card = d)
   : 𝓕.card ≤ 2 ^ (d-1) → two_colorable 𝓕 := by
   intro bnd
   have I : Fintype ({ x // x ∈ X } → Fin 2) := (by apply Fintype.ofFinite)
   set P : Measure (X → Fin 2) := (PMF.uniformOfFintype (X → Fin 2)).toMeasure with Pdef
   set E : (Finset X) → Finset (X → Fin 2) := (fun A => {c | ∀ x ∈ A, ∀ y ∈ A, c x = c y}) with Edef
-  have probaEA (A : Finset X) (hA : A ∈ 𝓕) : P (E A) = (1 / 2)^(d-1 : ℤ) := by
+  have probaEA (A : Finset X) (hA : A ∈ 𝓕) : P (E A) = (1 / 2)^(@Nat.cast ℤ _ (d-1)) := by
+    have forComp : d ≤ #X := by
+      rw [← H_𝓕 A hA] ; convert (card_le_univ A) ; simp only [Fintype.card_coe]
     rw [Pdef, PMF.toMeasure_uniformOfFintype_apply]
     · nth_rw 2 [← Nat.card_eq_fintype_card]
       rw [Nat.card_fun]
@@ -114,13 +111,15 @@ theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈
         Nat.cast_pow, Nat.cast_ofNat, one_div]
       rw [sizeEA]
       simp only [Nat.cast_pow, Nat.cast_ofNat]
-      rw [div_eq_mul_inv, ENNReal.mul_inv_eq_iff_eq_mul (by simp) (by simp) (by simp) (by sorry)]
-      rw [ENNReal.inv_zpow' 2 (d-1), ]
+      rw [div_eq_mul_inv, ENNReal.mul_inv_eq_iff_eq_mul (by simp) (by simp) (by simp)
+            (by rw [← show (2 : ENNReal)⁻¹ ^ (d-1) = 2⁻¹ ^ (@Nat.cast ℤ _ (d-1)) from by simp] ; simp)]
+      rw [@Nat.cast_sub _ _ 1 d (by omega), Nat.cast_one, ENNReal.inv_zpow' 2 (d-1)]
       rw [show (2 : ENNReal) ^ #X = 2 ^ (#X : ℤ) from by rw [zpow_natCast]]
-      rw [show (2 : ENNReal) ^ (#X - #A + 1) = 2 ^ ((#X - #A + 1) : ℤ) from by sorry ]
+      rw [show (2 : ENNReal) ^ (#X - #A + 1) = 2 ^ (@Nat.cast ℤ _ (#X - #A + 1)) from by rw [zpow_natCast]]
       rw [← ENNReal.zpow_add (by simp) (by simp)]
       rw [neg_sub, H_𝓕 A hA]
       congr 1
+      simp only [Nat.cast_add, Nat.cast_one, @Nat.cast_sub _ _ d #X forComp]
       ring
     · --measurability -- @Moritz ; solves it, but is slow
       exact Set.Finite.measurableSet <| finite_toSet (E A)
@@ -129,9 +128,7 @@ theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈
 
 #check pow_eq_top_iff
 #check WithTop.pow_eq_top_iff
-
 #check card_pos
-
 #check card_pi
 #check Nat.card_fun
 #check Nat.card
@@ -144,24 +141,22 @@ theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈
 #check PMF.toMeasure
 #check MeasurableSet.of_discrete
 #check DiscreteMeasurableSpace
-
 #check MeasurableSet.singleton
-
 #check div_pow
 #check div_eq_mul_inv
 #check mul_inv_eq_iff_eq_mul₀
 #check ENNReal.zpow_add
-
+#check ENNReal.inv_pow
 #check measure_ne_top
 #check measure_lt_top
-
 #check zpow_eq_neg_zpow_iff₀
-
 #check zpow_add₀
+#check card_le_univ
+#check PMF.uniformOfFinset
+#check PMF.uniformOfFintype
+#check PMF.toMeasure_apply
+#check MeasureTheory.measure_biUnion_le
 
-
-
-#check
 
 
 #exit

--- a/FormalBook/Chapter_45.lean
+++ b/FormalBook/Chapter_45.lean
@@ -8,6 +8,10 @@ import Mathlib.Data.Finset.Powerset
 --import Mathlib.Analysis.SpecialFunctions.Exp
 --import Mathlib.Analysis.SpecialFunctions.Log.Base
 
+import Mathlib.Probability.Distributions.Uniform
+import Mathlib.Probability.Notation
+
+
 
 open SimpleGraph Finset
 /-!
@@ -70,18 +74,57 @@ d-sets is itself 2-colorable."
 -/
 theorem remark_2 {𝓕 𝓢 : Finset (Finset X)}
   (h₁ : two_colorable 𝓕)  (h₂ : 𝓢 ⊆ 𝓕) : two_colorable 𝓢 := by
-  refine h₁.imp ?_
+  apply h₁.imp ?_
   intro coloring h₃ A Amem
   exact h₃ A (h₂ Amem)
 
 
 
+#check PMF.uniformOfFinset
+#check PMF.uniformOfFintype
+#check PMF.toMeasure_apply
+#check MeasureTheory.measure_biUnion_le
+
+open MeasureTheory
+
+theorem theorem_1 (𝓕 : Finset (Finset X)) (H_𝓕 : ∀ (A : Finset X), A ∈ 𝓕 → A.card = d)
+  : 𝓕.card ≤ 2 ^ (d-1) → two_colorable 𝓕 := by
+  have I : Fintype ({ x // x ∈ X } → Fin 2) := (by apply Fintype.ofFinite)
+  set P : Measure (X → Fin 2) := (PMF.uniformOfFintype (X → Fin 2)).toMeasure with Pdef
+  set E : (Finset X) → Finset (X → Fin 2) := (fun A => {c | ∀ x ∈ A, ∀ y ∈ A, c x = c y}) with Edef
+  have probaEA (A : Finset X) (hA : A ∈ 𝓕) : P (E A) = (1 / 2)^(d-1) := by
+    rw [Pdef, PMF.toMeasure_uniformOfFintype_apply]
+    · nth_rw 2 [← Nat.card_eq_fintype_card]
+      rw [Nat.card_fun]
+      have sizeEA : #(E A) = 2 ^ (#X - #A + 1) := by
+        sorry
+      simp only [coe_sort_coe, Fintype.card_coe, Nat.card_eq_fintype_card, Fintype.card_fin,
+        Nat.cast_pow, Nat.cast_ofNat, one_div]
+      rw [sizeEA]
+      simp only [Nat.cast_pow, Nat.cast_ofNat]
+      sorry
+    · sorry
+  sorry
+
+#check card_pos
+
+#check card_pi
+#check Nat.card_fun
+#check Nat.card
+#check card
+#check Nat.card_eq_fintype_card
+#check Nat.card_eq_finsetCard
+#check Fintype.ofFinite
+#check PMF.uniformOfFintype_apply
+#check PMF.toMeasure_apply_fintype
+#check PMF.toMeasure
+#check MeasurableSet.of_discrete
+#check DiscreteMeasurableSpace
+
+#check MeasurableSet.singleton
+
 
 #exit
-
---include H_𝓕 (H_𝓕 : ∀ (A : Finset X), A ∈ 𝓕 → A.card = d)
-theorem theorem_1 (𝓕 : Finset (Finset X)) : 𝓕.card ≤ 2 ^ (d-1) → two_colorable 𝓕 :=
-  sorry
 
 /-! Ramsey Numbers and Theorem 2-/
 


### PR DESCRIPTION
I added one more tiny remark from the book, and started working on theorem 1.
Some design decisions are:

-  Using `PMF.uniformOfFintype`. There's also `PMF.uniformOfFinset` in the same import and `ProbabilityTheory.uniformOn` in the mathlib file with the same name.
- Using `zpow`, to make computations work. 
- Not using the `measuability` tactic for elaboration speed.

Are there any changes in the direction taken you want to make ?