### PR TITLE
Fill two local arithmetic steps in Chapter 03

### DIFF
--- a/FormalBook/Chapter_03.lean
+++ b/FormalBook/Chapter_03.lean
@@ -150,7 +150,7 @@ theorem binomials_coefficients_never_powers (k l m n : ℕ) (h_2lel : 2 ≤ l) (
     -- STEP (4) : l ≥ 3 by Contradiction
     -- case l ≥ 3
     · have h_3lel : 3 ≤ l := by
-        sorry
+        omega
       -- main work : n < k³
       have h₄ : n < k^3 := by
         sorry
@@ -170,7 +170,7 @@ theorem binomials_coefficients_never_powers (k l m n : ℕ) (h_2lel : 2 ≤ l) (
     have h_k'_def : k' = n - k := by rfl
     -- third requirement: 2 * k' ≤ n
     have h_2k'len : 2 * k' ≤ n := by
-      sorry
+      omega
     -- second requirement: k ≤ n - 4
     have h_k'len4 : k' ≤ n - 4 := by
       simp only [h_k'_def, tsub_le_iff_right]


### PR DESCRIPTION
This fills two local arithmetic proof holes in `FormalBook/Chapter_03.lean` using `omega`.

Patch:

    have h_3lel : 3 ≤ l := by
      omega

and

    have h_2k'len : 2 * k' ≤ n := by
      omega

Local verification:

    lake build FormalBook.Chapter_03

Result:

    Build completed successfully

Sorry/admit count change in the file:

    -2

The patch is intentionally minimal and only replaces the two local `sorry` holes.
